### PR TITLE
記事一覧にもタグを表示する。

### DIFF
--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -21,6 +21,7 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            tags={post.tags}
           />
         ))}
       </div>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string;
   author: Author;
   slug: string;
+  tags: string[];
 };
 
 const PostPreview = ({
@@ -20,6 +21,7 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  tags,
 }: Props) => {
   return (
     <div>
@@ -38,6 +40,13 @@ const PostPreview = ({
             {title}
           </Link>
         </h3>
+        <ul className="flex gap-x-2">
+          {tags.map((tag, index) => (
+            <li key={index} className="font-bold mb-12">
+              <a href={`/tags/${tag}`}>{tag}</a>
+            </li>
+          ))}
+        </ul>
         <div className="flex flex-row">
           <Avatar name={author.name} picture={author.picture} />
           <div className="font-bold text-xs my-auto mx-2">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -55,7 +55,7 @@ export const getPostsByTag = (tag: string, fields: string[] = []) => {
     .sort((post1, post2) => (post1.date > post2.date ? -1 : 1));
 };
 
-export const getAllTags = () => {
+export const getAllTags = (): string[] => {
   const allPostTags = getAllPosts(["tags"])
     .flatMap((post) => post.tags)
     .sort();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,20 +1,20 @@
-import Container from '../components/container'
-import MoreStories from '../components/more-stories'
-import HeroPost from '../components/hero-post'
-import Intro from '../components/intro'
-import Layout from '../components/layout'
-import { getAllPosts } from '../lib/api'
-import Head from 'next/head'
-import { CMS_NAME } from '../lib/constants'
-import Post from '../interfaces/post'
+import Container from "../components/container";
+import MoreStories from "../components/more-stories";
+import HeroPost from "../components/hero-post";
+import Intro from "../components/intro";
+import Layout from "../components/layout";
+import { getAllPosts, getAllTags } from "../lib/api";
+import Head from "next/head";
+import { CMS_NAME } from "../lib/constants";
+import Post from "../interfaces/post";
 
 type Props = {
-  allPosts: Post[]
-}
+  allPosts: Post[];
+};
 
 export default function Index({ allPosts }: Props) {
-  const heroPost = allPosts[0]
-  const morePosts = allPosts.slice(1)
+  const heroPost = allPosts[0];
+  const morePosts = allPosts.slice(1);
   return (
     <>
       <Layout>
@@ -37,20 +37,21 @@ export default function Index({ allPosts }: Props) {
         </Container>
       </Layout>
     </>
-  )
+  );
 }
 
 export const getStaticProps = async () => {
   const allPosts = getAllPosts([
-    'title',
-    'date',
-    'slug',
-    'author',
-    'coverImage',
-    'excerpt',
-  ])
+    "title",
+    "date",
+    "slug",
+    "author",
+    "coverImage",
+    "excerpt",
+    "tags",
+  ]);
 
   return {
     props: { allPosts },
-  }
-}
+  };
+};


### PR DESCRIPTION
# やったこと
- タグ単位の記事一覧ページにtag情報を表示(記事ごと)
- tag情報をリンクを付与

# 関連issue
https://github.com/kanekou/kanekou-blog/issues/2
