### PR TITLE
ogImageをページごとに表示するよう修正

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-IMAGE_HOST=localhost:3000

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-IMAGE_HOST=https://kanekou-blog.web.app
+NEXT_PUBLIC_IMAGE_HOST=https://kanekou-blog.web.app

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,14 +1,15 @@
 import Alert from "./alert";
 import Meta from "./meta";
 import Header from "./header";
+import { SITE_OG_IMAGE } from "../lib/constants";
 
 type Props = {
   preview?: boolean;
+  ogImage?: string;
   children: React.ReactNode;
 };
 
-const Layout = ({ preview, children }: Props) => {
-  const imageUrl = `${process.env.IMAGE_HOST}/image.png`;
+const Layout = ({ preview, ogImage = SITE_OG_IMAGE, children }: Props) => {
   return (
     <>
       <Meta
@@ -16,7 +17,7 @@ const Layout = ({ preview, children }: Props) => {
         description="kanekouの技術ブログです"
         url="https://kanekou-blog.web.app"
         type="blog"
-        imageUrl={imageUrl}
+        ogImage={ogImage}
       />
       <div className="min-h-screen">
         <Header />

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -5,11 +5,11 @@ type Props = {
   description: string;
   url: string;
   type: string;
-  imageUrl: string;
+  ogImage: string;
 };
 
 // FIXME: SEO改善のために設定を行う
-const Meta = ({ title, description, url, type, imageUrl }: Props) => {
+const Meta = ({ title, description, url, type, ogImage }: Props) => {
   return (
     <Head>
       <link
@@ -43,7 +43,7 @@ const Meta = ({ title, description, url, type, imageUrl }: Props) => {
       <meta property="og:url" content={url} />
       <meta property="og:site_name" content={title} />
       <meta property="og:type" content={type} />
-      <meta property="og:image" content={imageUrl} />
+      <meta property="og:image" content={ogImage} />
     </Head>
   );
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const SITE_OG_IMAGE = `${process.env.NEXT_PUBLIC_IMAGE_HOST}/image.png`;

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -16,12 +16,12 @@ type Props = {
 
 export default function Post({ post, preview }: Props) {
   const router = useRouter();
-  const og_image = `${process.env.IMAGE_HOST}${post.ogImage.url}`;
+  const ogImage = `${process.env.NEXT_PUBLIC_IMAGE_HOST}${post.ogImage.url}`;
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />;
   }
   return (
-    <Layout preview={preview}>
+    <Layout preview={preview} ogImage={ogImage}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>
@@ -29,7 +29,6 @@ export default function Post({ post, preview }: Props) {
           <>
             <Head>
               <title>{post.title}</title>
-              <meta property="og:image" content={og_image} />
             </Head>
             <PostHeader
               title={post.title}


### PR DESCRIPTION
## 関連issue
#57 


## 概要
- 記事ページでは記事毎のogpイメージを表示するように変更。その他のページはサイト全体のOGPを表示するように変更
- 環境ごとにogp画像のpathを切り替えるように変更
